### PR TITLE
enable webpack production mode, shorten filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secondedition-fetch",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,11 @@
 const path = require("path");
 
 module.exports = {
-  mode: "development",
+  mode: "production",
   entry: "./build/index.js",
   output: {
     path: path.resolve(__dirname, "dist"),
-    filename: "secondedition.js",
+    filename: "umd.js",
     library: "se",
     libraryTarget: "umd",
   },


### PR DESCRIPTION
Two things:
- use webpack's production mode (oops: the final file goes from ~75Kb -> ~20Kb)
- shorten the filename, so includes can be something like https://cdn.jsdelivr.net/npm/secondedition-fetch@0.0.2/dist/umd.js

Seems like a *lot* more I can do with webpack, e.g. handle sourcemaps, but I'll handle that some other time.

Also bump the version number.